### PR TITLE
Update default rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The script supports additional parameters to customize its behavior:
 
 - `--body-max-line-length`: Maximum length of a line in the commit message body. Defaults to `100`.
 
+- `--summary-uppercase`: Summary must start with an uppercase letter. If not specified, the default is `false` (uppercase not required).
+
 You can modify these parameters by adding them to the `args` array in the `.pre-commit-config.yaml` file. For example, to change the `--subject-min-length` to `10` and add a new type `fox`, your configuration would look like this:
 
 ```yaml
@@ -59,9 +61,9 @@ Where:
 
 - `<scope/component>` (optional): the scope or component that the commit pertains to. It should start with a lowercase letter.
 
-- `<Summary>`: a short, concise description of the change. It should start with a capital letter, not end with a period, and be between `subject_min_length` and `subject_max_length` characters long (as specified by script parameters).
+- `<summary>`: a short, concise description of the change. It should not end with a period, and be between `subject_min_length` and `subject_max_length` characters long (as specified by script parameters). If the `--summary-uppercase` flag is used, then the summary must start with a uppercase letter.
 
-- `<Body>` (optional): a detailed description of the change. Each line should be no longer than `body_max_line_length` characters (as specified by script parameters). There should be one blank line between the summary and the body.
+- `<body>` (optional): a detailed description of the change. Each line should be no longer than `body_max_line_length` characters (as specified by script parameters). There should be one blank line between the summary and the body.
 
 Examples:
 
@@ -72,7 +74,7 @@ This is a detailed description of the commit message body ...
 
 ...
 
-ci: Added target test job for ESP32-Wifi6
+ci: added target test job for ESP32-Wifi6
 
 ...
 ```

--- a/conventional_precommit_linter/hook.py
+++ b/conventional_precommit_linter/hook.py
@@ -26,7 +26,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
         '--subject-min-length', type=int, default=20, help="Minimum length of the 'Summary' field in commit message"
     )
     parser.add_argument(
-        '--subject-max-length', type=int, default=50, help="Maximum length of the 'Summary' field in commit message"
+        '--subject-max-length', type=int, default=72, help="Maximum length of the 'Summary' field in commit message"
     )
     parser.add_argument(
         '--body-max-line-length', type=int, default=100, help='Maximum length of the line in message body'

--- a/conventional_precommit_linter/hook.py
+++ b/conventional_precommit_linter/hook.py
@@ -31,6 +31,9 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument(
         '--body-max-line-length', type=int, default=100, help='Maximum length of the line in message body'
     )
+    parser.add_argument(
+        '--summary-uppercase', action='store_true', help='Summary must start with an uppercase letter'
+    )
     parser.add_argument('input', type=str, help='A file containing a git commit message')
     return parser.parse_args(argv)
 
@@ -58,7 +61,6 @@ def raise_error(message: str, error: str, types: str, args: argparse.Namespace) 
     commit message rules:
         - use one of the following types: [{types}]
         - 'scope/component' is optional, but if used, it must start with a lowercase letter
-        - 'summary' must start with a capital letter
         - 'summary' must not end with a period
         - 'summary' must be between {args.subject_min_length} and {args.subject_max_length} characters long
         - 'body' is optional, but if used, lines must be no longer than {args.body_max_line_length} characters
@@ -72,7 +74,7 @@ def raise_error(message: str, error: str, types: str, args: argparse.Namespace) 
         ...
 
     Example of a good commit message (without scope and body):
-        ci: Added target test job for ESP32-Wifi6
+        ci: added target test job for ESP32-Wifi6
 
         ...
     """
@@ -135,7 +137,7 @@ def parse_commit_message(args: argparse.Namespace, input_commit_message: str) ->
         raise_error(message_title, error, types, args)
 
     # Check if the 'summary' starts with a lowercase letter
-    if commit_summary[0].islower():
+    if args.summary_uppercase and commit_summary[0].islower():
         raise_error(message_title, ERROR_SUMMARY_CAPITALIZATION, types, args)
 
     # Check if the 'summary' ends with a period (full stop)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conventional_precommit_linter"
-version = "1.0.0"
+version = "1.1.0"
 description = "A pre-commit hook that checks commit messages for Conventional Commits formatting."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_custom_args.py
+++ b/tests/test_custom_args.py
@@ -1,0 +1,175 @@
+import tempfile
+
+import pytest
+
+from conventional_precommit_linter.hook import ERROR_BODY_FORMAT
+from conventional_precommit_linter.hook import ERROR_BODY_LENGTH
+from conventional_precommit_linter.hook import ERROR_EMPTY_MESSAGE
+from conventional_precommit_linter.hook import ERROR_MISSING_COLON
+from conventional_precommit_linter.hook import ERROR_SCOPE_CAPITALIZATION
+from conventional_precommit_linter.hook import ERROR_SUMMARY_CAPITALIZATION
+from conventional_precommit_linter.hook import ERROR_SUMMARY_LENGTH
+from conventional_precommit_linter.hook import ERROR_SUMMARY_PERIOD
+from conventional_precommit_linter.hook import ERROR_TYPE
+from conventional_precommit_linter.hook import main
+
+# Input arguments
+TYPES = 'change, ci, docs, feat, fix, refactor, remove, revert, fox'
+SUBJECT_MIN_LENGTH = 21
+SUBJECT_MAX_LENGTH = 53
+BODY_MAX_LINE_LENGTH = 101
+SUMMARY_UPPERCASE = True
+
+
+# Fixture for messages
+@pytest.fixture(
+    params=[
+        (
+            # Expected PASS: Message with scope and body
+            'feat(bootloader): This is commit message with scope and body\n\nThis is a text of body',
+            True,
+            None,
+        ),
+        (
+            # Expected PASS: Message with scope, without body
+            'change(wifi): This is commit message with scope without body',
+            True,
+            None,
+        ),
+        (
+            # Expected PASS: Message with scope (with hyphen in scope), without body
+            'change(esp-rom): This is commit message with hyphen in scope',
+            True,
+            None,
+        ),
+        (
+            # Expected PASS: Message without scope, with body
+            'change: This is commit message without scope with body\n\nThis is a text of body',
+            True,
+            None,
+        ),
+        (
+            # Expected PASS: Message without scope, without body
+            'change: This is commit message without scope and body',
+            True,
+            None,
+        ),
+        (
+            # Expected PASS: Test of additional types
+            'fox(esp32): Testing additional types\n\nThis is a text of body',
+            True,
+            None,
+        ),
+        (
+            # Expected FAIL: missing colon between 'type' (and 'scope') and 'summary'
+            'change this is commit message without body',
+            False,
+            ERROR_MISSING_COLON,
+        ),
+        (
+            # Expected FAIL: 'summary' too short
+            'fix: Fix bug',
+            False,
+            ERROR_SUMMARY_LENGTH.format(SUBJECT_MIN_LENGTH, SUBJECT_MAX_LENGTH),
+        ),
+        (
+            # Expected FAIL: 'summary' too long
+            'change(rom): Refactor authentication flow for enhanced security measures',
+            False,
+            ERROR_SUMMARY_LENGTH.format(SUBJECT_MIN_LENGTH, SUBJECT_MAX_LENGTH),
+        ),
+        (
+            # Expected FAIL: 'summary' ends with period
+            'change(rom): Fixed the another bug.',
+            False,
+            ERROR_SUMMARY_PERIOD,
+        ),
+        (
+            # Expected FAIL: 'summary' starts with lowercase
+            'change(rom): this message starts with lowercase',
+            False,
+            ERROR_SUMMARY_CAPITALIZATION,
+        ),
+        (
+            # Expected FAIL: uppercase in 'scope'
+            'change(Bt): Added new feature with change\n\nThis feature adds functionality',
+            False,
+            ERROR_SCOPE_CAPITALIZATION,
+        ),
+        (
+            # Expected FAIL: not allowed 'type' with scope and body
+            'delete(bt): Added new feature with change\n\nThis feature adds functionality',
+            False,
+            # Adjusted expected error message
+            ERROR_TYPE.format(TYPES),
+        ),
+        (
+            # Expected FAIL: not allowed 'type' without scope and without body
+            'wip: Added new feature with change',
+            False,
+            # Adjusted expected error message
+            ERROR_TYPE.format(TYPES),
+        ),
+        (
+            # Expected FAIL: not allowed 'type' (type starts with uppercase)
+            'Fix(bt): Added new feature with change\n\nThis feature adds functionality',
+            False,
+            ERROR_TYPE.format(TYPES),
+        ),
+        (
+            # Expected FAIL: missing blank line between 'summary' and 'body'
+            'change: Added new feature with change\nThis feature adds functionality',
+            False,
+            ERROR_BODY_FORMAT,
+        ),
+        (
+            # Expected FAIL: 'body' line too long
+            'fix(bt): Update database schemas\n\nUpdating the database schema to include new fields and user profile preferences, cleaning up unnecessary calls',  # noqa: E501
+            False,
+            ERROR_BODY_LENGTH.format(1),  # 1 here means found one line that is too long
+        ),
+        (
+            # Expected FAIL: empty commit message
+            '   \n\n   \n',
+            False,
+            ERROR_EMPTY_MESSAGE,
+        ),
+    ]
+)
+def message(request):
+    return request.param
+
+
+def test_commit_message(message, capsys):
+    # Unpack the message, the expectation, and the expected error message
+    message_text, should_pass, expected_error = message
+
+    # Convert the constants into a list of command-line arguments
+    argv = [
+        '--types',
+        TYPES.replace(', ', ','),
+        '--subject-min-length',
+        str(SUBJECT_MIN_LENGTH),
+        '--subject-max-length',
+        str(SUBJECT_MAX_LENGTH),
+        '--body-max-line-length',
+        str(BODY_MAX_LINE_LENGTH),
+        '--summary-uppercase',
+    ]
+
+    # Create a temporary file and write the commit message to it
+    with tempfile.NamedTemporaryFile(delete=False) as temp:
+        temp.write(message_text.encode())
+        temp_file_name = temp.name
+
+    # Add the path of the temp file to the arguments
+    argv.append(temp_file_name)
+
+    # If the message is expected to be invalid, check that it raises SystemExit and that the error message matches
+    if not should_pass:
+        with pytest.raises(SystemExit):
+            main(argv)
+        captured = capsys.readouterr()
+        assert expected_error in captured.out
+    else:
+        main(argv)


### PR DESCRIPTION
### Change default rules
- set default maximum length of summary to 72 characters (before 50 characters)
- drop rule enforcing uppercase on the beginning of the summary (https://github.com/espressif/conventional-precommit-linter/issues/2)