### PR TITLE
Ignore comment lines from linted commit message

### DIFF
--- a/conventional_precommit_linter/hook.py
+++ b/conventional_precommit_linter/hook.py
@@ -78,7 +78,7 @@ def raise_error(message: str, error: str, types: str, args: argparse.Namespace) 
     """
 
     print(f'{full_error_msg}{guide_good_message}')
-
+    print('\n\033[93m 👉 To preserve and correct a commit message, run\033[92m git commit --edit --file=.git/COMMIT_EDITMSG \033[0m')  # noqa: E501
     raise SystemExit(1)
 
 

--- a/conventional_precommit_linter/hook.py
+++ b/conventional_precommit_linter/hook.py
@@ -31,9 +31,7 @@ def parse_args(argv: List[str]) -> argparse.Namespace:
     parser.add_argument(
         '--body-max-line-length', type=int, default=100, help='Maximum length of the line in message body'
     )
-    parser.add_argument(
-        '--summary-uppercase', action='store_true', help='Summary must start with an uppercase letter'
-    )
+    parser.add_argument('--summary-uppercase', action='store_true', help='Summary must start with an uppercase letter')
     parser.add_argument('input', type=str, help='A file containing a git commit message')
     return parser.parse_args(argv)
 
@@ -87,7 +85,10 @@ def raise_error(message: str, error: str, types: str, args: argparse.Namespace) 
 def read_commit_message(file_path: str) -> str:
     try:
         with open(file_path, encoding='utf-8') as f:
-            content = f.read()
+            lines = f.readlines()
+            # Remove lines starting with '#'
+            lines = [line for line in lines if not line.startswith('#')]
+            content = ''.join(lines)
             if not content.strip():
                 print(f'❌ {ERROR_EMPTY_MESSAGE}')
                 raise SystemExit(1)

--- a/tests/test_custom_args.py
+++ b/tests/test_custom_args.py
@@ -44,7 +44,7 @@ SUMMARY_UPPERCASE = True
         ),
         (
             # Expected PASS: Message without scope, with body
-            'change: This is commit message without scope with body\n\nThis is a text of body',
+            'change: This is commit message without scope with body\n\nThis is a text of body\n# Please enter the commit message for your changes. Lines starting\n# with \'#\' will be ignored, and an empty message aborts the commit.\n#',  # noqa: E501
             True,
             None,
         ),

--- a/tests/test_custom_args.py
+++ b/tests/test_custom_args.py
@@ -43,6 +43,24 @@ SUMMARY_UPPERCASE = True
             None,
         ),
         (
+            # Expected PASS: Message with scope (with asterisk in scope), without body
+            'change(examples*storage): This is commit message with asterisk in scope',
+            True,
+            None,
+        ),
+        (
+            # Expected PASS: Message with scope (with comma in scope), without body
+            'change(examples,storage): This is commit message with comma in scope',
+            True,
+            None,
+        ),
+        (
+            # Expected PASS: Message with scope (with slash in scope), without body
+            'change(examples/storage): This is commit message with slash in scope',
+            True,
+            None,
+        ),
+        (
             # Expected PASS: Message without scope, with body
             'change: This is commit message without scope with body\n\nThis is a text of body\n# Please enter the commit message for your changes. Lines starting\n# with \'#\' will be ignored, and an empty message aborts the commit.\n#',  # noqa: E501
             True,

--- a/tests/test_default_args.py
+++ b/tests/test_default_args.py
@@ -41,6 +41,24 @@ BODY_MAX_LINE_LENGTH = 100
             None,
         ),
         (
+            # Expected PASS: Message with scope (with asterisk in scope), without body
+            'change(examples*storage): This is commit message with asterisk in scope',
+            True,
+            None,
+        ),
+        (
+            # Expected PASS: Message with scope (with comma in scope), without body
+            'change(examples,storage): This is commit message with comma in scope',
+            True,
+            None,
+        ),
+        (
+            # Expected PASS: Message with scope (with slash in scope), without body
+            'change(examples/storage): This is commit message with slash in scope',
+            True,
+            None,
+        ),
+        (
             # Expected PASS: Message without scope, with body
             'change: This is commit message without scope with body\n\nThis is a text of body\n# Please enter the commit message for your changes. Lines starting\n# with \'#\' will be ignored, and an empty message aborts the commit.\n#',  # noqa: E501
             True,

--- a/tests/test_default_args.py
+++ b/tests/test_default_args.py
@@ -42,7 +42,7 @@ BODY_MAX_LINE_LENGTH = 100
         ),
         (
             # Expected PASS: Message without scope, with body
-            'change: This is commit message without scope with body\n\nThis is a text of body',
+            'change: This is commit message without scope with body\n\nThis is a text of body\n# Please enter the commit message for your changes. Lines starting\n# with \'#\' will be ignored, and an empty message aborts the commit.\n#',  # noqa: E501
             True,
             None,
         ),


### PR DESCRIPTION
- add additional allowed special characters in the scope/component, (`/` `.` `,` `*` to already allowed `_` and `-` ) + tests for it
- add a hint/tip on how to retrieve and edit the failed commit message
- add line skipping starting with `#` in the message body (git default comment)