### PR TITLE
Update scope regex to be consistent with commitlint in DangerJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Where:
 
 - `<type>`: a descriptor of the performed change, e.g., `feat`, `fix`, `refactor`, etc. Use one of the specified types (either default or provided using the `--types` parameter).
 
-- `<scope/component>` (optional): the scope or component that the commit pertains to. It should start with a lowercase letter.
+- `<scope/component>` (optional): the scope or component that the commit pertains to. It should be written in lower case without whitespace, allowed special characters in `scope` are `_` `/` `.` `,` `*` `-` `.`
 
 - `<summary>`: a short, concise description of the change. It should not end with a period, and be between `subject_min_length` and `subject_max_length` characters long (as specified by script parameters). If the `--summary-uppercase` flag is used, then the summary must start with a uppercase letter.
 

--- a/conventional_precommit_linter/hook.py
+++ b/conventional_precommit_linter/hook.py
@@ -9,7 +9,7 @@ DEFAULT_TYPES = ['change', 'ci', 'docs', 'feat', 'fix', 'refactor', 'remove', 'r
 ERROR_EMPTY_MESSAGE = 'Commit message seems to be empty.'
 ERROR_MISSING_COLON = "Missing colon after 'type' or 'scope'. Ensure the commit message has the format '<type><(scope/component)>: <summary>'."  # noqa: E501
 ERROR_TYPE = "Issue with 'type'. Ensure the type is one of [{}]."
-ERROR_SCOPE_CAPITALIZATION = "Issue with 'scope'. Ensure the scope starts with a lowercase letter. Allowed special characters in `scope` are _ / . , * -"  # noqa: E501
+ERROR_SCOPE_CAPITALIZATION = "Issue with 'scope'. Ensure the 'scope' is written in lower case without whitespace. Allowed special characters in 'scope' are _ / . , * -"  # noqa: E501
 ERROR_SUMMARY_LENGTH = "Issue with 'summary'. Ensure the summary is between {} and {} characters long."
 ERROR_SUMMARY_CAPITALIZATION = "Issue with 'summary'. Ensure the summary starts with an uppercase letter."
 ERROR_SUMMARY_PERIOD = "Issue with 'summary'. Ensure the summary does not end with a period."
@@ -50,7 +50,7 @@ def raise_error(message: str, error: str, types: str, args: argparse.Namespace) 
 
     commit message rules:
         - use one of the following types: [{types}]
-        - 'scope/component' is optional, but if used, it must start with a lowercase letter
+        - 'scope/component' is optional, but if used, must be written in lower case without whitespace
         - 'summary' must not end with a period
         - 'summary' must be between {args.subject_min_length} and {args.subject_max_length} characters long
         - 'body' is optional, but if used, lines must be no longer than {args.body_max_line_length} characters
@@ -122,7 +122,7 @@ def parse_commit_message(args: argparse.Namespace, input_commit_message: str) ->
         raise_error(message_title, error, types, args)
 
     # If 'scope' is provided, check for valid 'scope'
-    REGEX_SCOPE = r'^[a-z][a-zA-Z0-9_/.,*-]*$'
+    REGEX_SCOPE = r'^[a-z0-9_/.,*-]*$'
     if commit_scope and not re.match(REGEX_SCOPE, commit_scope):
         raise_error(message_title, ERROR_SCOPE_CAPITALIZATION, types, args)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "conventional_precommit_linter"
-version = "1.1.0"
+version = "1.2.1"
 description = "A pre-commit hook that checks commit messages for Conventional Commits formatting."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_custom_args.py
+++ b/tests/test_custom_args.py
@@ -115,6 +115,12 @@ SUMMARY_UPPERCASE = True
             ERROR_SCOPE_CAPITALIZATION,
         ),
         (
+            # Expected FAIL: uppercase in 'scope'
+            'fix(dangerGH): Update token permissions - allow Danger to add comments to PR',
+            False,
+            ERROR_SCOPE_CAPITALIZATION,
+        ),
+        (
             # Expected FAIL: not allowed 'type' with scope and body
             'delete(bt): Added new feature with change\n\nThis feature adds functionality',
             False,

--- a/tests/test_default_args.py
+++ b/tests/test_default_args.py
@@ -107,6 +107,12 @@ BODY_MAX_LINE_LENGTH = 100
             ERROR_SCOPE_CAPITALIZATION,
         ),
         (
+            # Expected FAIL: uppercase in 'scope'
+            'fix(dangerGH): Update token permissions - allow Danger to add comments to PR',
+            False,
+            ERROR_SCOPE_CAPITALIZATION,
+        ),
+        (
             # Expected FAIL: not allowed 'type' with scope and body
             'delete(bt): Added new feature with change\n\nThis feature adds functionality',
             False,


### PR DESCRIPTION
This change addresses a small inconsistency between the `@commitlint` plugin used in DangerJS and this pre-commit hook tool.

The issue is capitalization in the `scope` optional input field.

**DangerJS scope:** enforces **all letters in scope as lowercase** (+ allowed special characters)
**Conventional-precommit-linter scope:** enforces **only first character lowercase** (+ allowed special characters)

After change
**both** tools: enforces **all letters in scope as lowercase (+ allowed special characters)**

## Related
- IDFCI-1772