### PR TITLE
Add support for optional `!` in commit type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 *.egg*
 test_message.txt
 .coverage
+.vscode
+venv

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ minimum_pre_commit_version: 3.3.0
 default_install_hook_types: [pre-commit,commit-msg]
 ...
 ```
-After modifying `.pre-commit-config.yaml`, re-run the install command (`pre-commit install`) for changes to take effect.
+After modifying `.pre-commit-config.yaml`, re-run the installation command (`pre-commit install`) for changes to take effect.
 
 ---
 
@@ -87,6 +87,7 @@ The linter accepts several configurable parameters to tailor commit message vali
 - `--subject-max-length`: Set the maximum length for the summary (default: `72`).
 - `--body-max-line-length`: Set the maximum line length for the body (default: `100`).
 - `--summary-uppercase`: Enforce the summary to start with an uppercase letter (default: `disabled`).
+- `--allow-breaking`: Allow exclamation mark in the commit type (default: `false`).
 
 The **custom configuration** can be specified in `.pre-commit-config.yaml` like this:
 ```yaml

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+
+from conventional_precommit_linter.hook import rules_output_status
+
+
+@pytest.fixture(scope='session')
+def default_rules_output_status():
+    return rules_output_status.copy()

--- a/tests/test_default_args.py
+++ b/tests/test_default_args.py
@@ -11,20 +11,6 @@ SUBJECT_MIN_LENGTH = 20
 SUBJECT_MAX_LENGTH = 72
 BODY_MAX_LINE_LENGTH = 100
 
-# Default dictionary with all values set to False
-default_rules_output_status = {
-    'empty_message': False,
-    'error_body_format': False,
-    'error_body_length': False,
-    'error_scope_capitalization': False,
-    'error_scope_format': False,
-    'error_summary_capitalization': False,
-    'error_summary_length': False,
-    'error_summary_period': False,
-    'error_type': False,
-    'missing_colon': False,
-}
-
 
 # Dynamic test naming based on the commit message
 def commit_message_id(commit_message):  # pylint: disable=redefined-outer-name
@@ -77,6 +63,21 @@ def commit_message_id(commit_message):  # pylint: disable=redefined-outer-name
             # Expected PASS: 'summary' starts with lowercase
             'change(rom): this message starts with lowercase',
             {},
+        ),
+        (
+            # Expected FAIL: Message without scope with exclamation mark
+            'change!: This is commit message without scope but with exclamation mark',
+            {'error_breaking': True},
+        ),
+        (
+            # Expected FAIL: Message with scope with exclamation mark
+            'change(rom)!: This is commit message with scope and with exclamation mark',
+            {'error_breaking': True},
+        ),
+        (
+            # Expected FAIL: Message with scope with 2 exclamation marks
+            'change(rom)!!: This is commit message with !!',
+            {'error_type': True},
         ),
         (
             # Expected FAIL: missing colon between 'type' (and 'scope') and 'summary'
@@ -162,13 +163,13 @@ def commit_message_id(commit_message):  # pylint: disable=redefined-outer-name
     # Use the commit message to generate IDs for each test case
     ids=commit_message_id,
 )
-def commit_message(request):
+def commit_message(request, default_rules_output_status):
     # Combine the default dictionary with the test-specific dictionary
     combined_output = {**default_rules_output_status, **request.param[1]}
     return request.param[0], combined_output
 
 
-def test_commit_message(commit_message):  # pylint: disable=redefined-outer-name
+def test_commit_message(commit_message, default_rules_output_status):  # pylint: disable=redefined-outer-name
     message_text, expected_output = commit_message
 
     # Reset rules_output_status to its default state before each test case


### PR DESCRIPTION
This PR adds support for optional `!` as described in the standard. By default, this is not allowed, but can be enabled with `--allow-breaking` flag.

Closes #12 