### PR TITLE
change(default-types): add "test:" to default commit types

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ After modifying `.pre-commit-config.yaml`, re-run the installation command (`pre
 ## Configuration
 
 The linter accepts several configurable parameters to tailor commit message validation:
-- `--types`: Define the types of commits allowed (default: [`change`, `ci`, `docs`, `feat`, `fix`, `refactor`, `remove`, `revert`]).
+- `--types`: Define the types of commits allowed (default: [`change`, `ci`, `docs`, `feat`, `fix`, `refactor`, `remove`, `revert`, `test`]).
 - `--scopes`: Specifies a list of allowed scopes. If not defined, all scopes are allowed (restriction is `disabled`).
 - `--subject-min-length`: Set the minimum length for the summary (default: `20`).
 - `--subject-max-length`: Set the maximum length for the summary (default: `72`).

--- a/conventional_precommit_linter/hook.py
+++ b/conventional_precommit_linter/hook.py
@@ -11,7 +11,7 @@ from .helpers import _color_grey
 from .helpers import _color_orange
 from .helpers import _color_purple
 
-DEFAULT_TYPES = ['change', 'ci', 'docs', 'feat', 'fix', 'refactor', 'remove', 'revert']
+DEFAULT_TYPES = ['change', 'ci', 'docs', 'feat', 'fix', 'refactor', 'remove', 'revert', 'test']
 
 rules_output_status = {
     'empty_message': False,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,7 @@
             "refactor",
             "remove",
             "revert",
+            "test",
         ]
         example = "change: this is a custom change type"
         message_template = "{% if scope %}{{change_type}}({{scope}}): {{message}}{% else %}{{change_type}}: {{message}}{% endif %}{% if body %}\n\n{{body}}{% endif %}{% if is_breaking_change %}\n\nBREAKING CHANGE{% endif %}{% if footer %}\n\n{{footer}}{% endif %}"
@@ -132,6 +133,7 @@
                 { value = "refactor", name = "refactor: A code change that neither fixes a bug nor adds a feature." },
                 { value = "remove", name = "remove: Removing code or files." },
                 { value = "revert", name = "revert: Revert to a commit." },
+                { value = "test", name = "test: Test script changes." },
             ]
             message = "Select the TYPE of change you are committing"
             name = "change_type"

--- a/tests/test_default_args.py
+++ b/tests/test_default_args.py
@@ -6,7 +6,7 @@ from conventional_precommit_linter.hook import main
 from conventional_precommit_linter.hook import rules_output_status
 
 # Default values for the commit message format
-TYPES = 'change, ci, docs, feat, fix, refactor, remove, revert'
+TYPES = 'change, ci, docs, feat, fix, refactor, remove, revert, test'
 SUBJECT_MIN_LENGTH = 20
 SUBJECT_MAX_LENGTH = 72
 BODY_MAX_LINE_LENGTH = 100
@@ -22,6 +22,11 @@ def commit_message_id(commit_message):  # pylint: disable=redefined-outer-name
         (
             # Expected PASS: Message with scope and body
             'feat(bootloader): This is commit message with scope and body\n\nThis is a text of body',
+            {},
+        ),
+        (
+            # Expected PASS: Message with scope and body, type "test"
+            'test(sync-script): This is commit message with scope and type test\n\nThis is a text of body',
             {},
         ),
         (


### PR DESCRIPTION
Adding commit type `test: ` (Adding missing tests or correcting existing tests, test script changes) to default allowed types

## Related
- https://github.com/espressif/conventional-precommit-linter/issues/18

## ToDo
- update defaults in https://github.com/espressif/shared-github-dangerjs/blob/v1/src/configParameters.ts#L18
- update defaults in Shared Gitlab Danger