### PR TITLE
ci(dependabot): add dependabot configuration to the repository

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,42 @@
+---
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    versioning-strategy: increase-if-necessary # Only increase the version if necessary (instead always latest)
+    directory: '/' # The directory where Dependabot should look for pip dependencies.
+    # schedule: { interval: weekly, day: sunday, time: '09:00' } # UTC
+    schedule: { interval: daily, time: '09:00' } # UTC
+    open-pull-requests-limit: 0 #  Disables PRs for version-updates, only security updates
+    groups:
+      # pip-version-updates: # (disabled)
+      #   applies-to: version-updates
+      #   patterns: ['*']
+      #   update-types: [major, minor, patch]
+      pip-security-updates:
+        applies-to: security-updates
+        patterns: ['*']
+        update-types: [major, minor, patch] # All types in same group (same PR)
+    commit-message: { prefix: 'ci(deps-pip): [skip ci]' } # Commit message prefix; [skip ci] disables GitHub workflows
+    reviewers: ['tomassebestik'] # the CI team Espressif GitHub organization
+    labels: ['dependencies', 'Status: Reviewing'] # Labels automatically added to the pull request
+    pull-request-branch-name: { separator: '-' } # Separator for PR branch names
+
+  - package-ecosystem: github-actions
+    open-pull-requests-limit: 0 # Only security updates
+    directory: '/'
+    # schedule: { interval: weekly, day: sunday, time: '09:00' } # UTC
+    schedule: { interval: daily, time: '09:00' } # UTC
+    groups:
+      # github-actions-version-updates: # (disabled)
+      #   applies-to: version-updates
+      #   patterns: ['*']
+      #   update-types: [major, minor, patch]
+      github-actions-security-updates:
+        applies-to: security-updates
+        patterns: ['*']
+        update-types: [major, minor, patch]
+    commit-message: { prefix: 'ci(deps-gh-actions): [skip ci]' }
+    reviewers: ['tomassebestik']
+    labels: ['dependencies', 'Status: Reviewing']
+    pull-request-branch-name: { separator: '-' }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,7 +34,6 @@ repos:
     rev: v1.9.0
     hooks:
     -   id: mypy                                         # Runs mypy for Python type checking
-        additional_dependencies: ['types-all']
 
   - repo: https://github.com/espressif/conventional-precommit-linter
     rev: v1.6.0


### PR DESCRIPTION
## Description
- add dependabot settings to the project - also as test for Espressif default `dependabot.yml` file

## Related
- https://github.com/espressif/sync-jira-actions/pull/17