### PR TITLE
fix: handle git scissor line in commit message parsing (RDT-1556)

### DIFF
--- a/conventional_precommit_linter/hook.py
+++ b/conventional_precommit_linter/hook.py
@@ -46,6 +46,16 @@ def get_allowed_scopes(args: argparse.Namespace) -> List[str]:
 def read_commit_message(file_path: str) -> str:
     with open(file_path, encoding='utf-8') as file:
         lines = file.readlines()
+
+        scissor_line_index = None
+        for i, line in enumerate(lines):
+            if line.strip() == '# ------------------------ >8 ------------------------':
+                scissor_line_index = i
+                break
+
+        if scissor_line_index is not None:
+            lines = lines[:scissor_line_index]
+
         lines = [line for line in lines if not line.startswith('#')]  # Remove comment lines (starting with '#')
         content = ''.join(lines)
         if not content.strip():

--- a/tests/test_custom_args.py
+++ b/tests/test_custom_args.py
@@ -262,6 +262,12 @@ def commit_message_id(commit_message):  # pylint: disable=redefined-outer-name
             {'error_summary_period': True},
             get_argv_list(scope_case_insensitive_arg=True),
         ),
+        (
+            # Expected PASS: Message with scissor line and diff content that should be ignored
+            'fix(bt): Update database configuration\n\nThis change updates the database configuration for better performance.\n# Please enter the commit message for your changes.\n# Lines starting with \'#\' will be ignored.\n#\n# On branch feature-branch\n# Changes to be committed:\n#\tnew file:   src/config.js\n#\tmodified:   package.json\n#\n# ------------------------ >8 ------------------------\n# Do not modify or remove the line above.\n# Everything below it will be ignored.\ndiff --git a/src/config.js b/src/config.js\nnew file mode 100644\nindex 0000000..1234567\n--- /dev/null\n+++ b/src/config.js\n@@ -0,0 +1,5 @@\n+module.exports = { database: { host: "averylonglinethatwouldbreaknormallybutthisshouldbeignored" } };',
+            {},
+            get_argv_list(),
+        ),
     ],
     # Use the commit message to generate IDs for each test case
     ids=commit_message_id,


### PR DESCRIPTION
## Description

Fixes commit message validation failure when using `git commit --verbose`. The hook incorrectly validated diff content that appears after Git's scissor line (`# ------------------------ >8 ------------------------`), failing when diff lines exceeded the body length limit.

**Changes:**
- Modified `read_commit_message()` to detect and strip content after the scissor line
- Added test coverage for this scenario

**Rationale:** Git's scissor line behavior is documented to ignore everything after this marker, but the linter was processing the entire file including verbose output.

## Related

- [Git commit documentation](https://git-scm.com/docs/git-commit#Documentation/git-commit.txt---verbose) on verbose mode
- [Git scissor line behavior](https://github.com/git/git/blob/fd372d9b1a69a01a676398882bbe3840bf51fe72/t/t7502-commit-porcelain.sh#L586-L611) in Git source tests

## Testing

- All existing tests pass (65/65)
- Added specific test case with scissor line + diff content
- Manual testing with `git commit --verbose` confirms fix
- No breaking changes to existing functionality